### PR TITLE
Switch nodemon to node as start due to crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "script.js",
   "scripts": {
-    "start": "nodemon server.js"
+    "start": "node server.js",
+    "start:dev": "nodemon server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
When deployed to heroku, getting crash app diff from the one in course, 
I had to look overflow for solution, and found out (after a while) that Heroku is not reading devDependencies, and reporting ERROR as NO NODEMON install.. (not sure if only for windows..)

File change is  - nodemon to START app as DEV. 

But, when deploying to Heroku, node js will be the one starting it.

Hope this help if anyone else had same or similar issue. And ofc glad if I can help anyhow..

Best regards

Marko T